### PR TITLE
Replace merge with flattenAndMerge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: 16.x
       - run: npm ci
-      - run: npm run format-check
+      - run: npm run format:check
       - run: npm run build
 
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.2.0
+- Replace `merge` with `flattenAndMerge` to flatten objects and merge
+
 ## v1.1.0
 - Add `merge` function to merge deep merge objects
 - Add `readTextFile` function to read text files with encoding

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qetza/replacetokens",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "replace tokens in files",
   "author": "Guillaume ROUCHON",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "build": "tsc",
     "test": "jest",
     "format": "prettier --write **/*.ts",
-    "format-check": "prettier --check **/*.ts"
+    "format:check": "prettier --check **/*.ts"
   },
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/src/bin/run.ts
+++ b/src/bin/run.ts
@@ -14,7 +14,7 @@ export async function run() {
   // parse arguments
   var argv = await yargs(process.argv.slice(2))
     .scriptName('replacetokens')
-    .version('1.1.0')
+    .version('1.2.0')
     .usage('$0 [args]')
     .help()
     .options({
@@ -189,7 +189,7 @@ export async function run() {
 
   try {
     // replace tokens
-    const result = await rt.replaceTokens(argv.sources, await parseVariables(argv.variables), {
+    const result = await rt.replaceTokens(argv.sources, await parseVariables(argv.variables, argv.separator), {
       root: argv.root,
       encoding: argv.encoding,
       token: {
@@ -232,7 +232,7 @@ export async function run() {
   }
 }
 
-async function parseVariables(variables: string[]): Promise<{ [key: string]: any }> {
+async function parseVariables(variables: string[], separator: string): Promise<{ [key: string]: any }> {
   variables = variables || ['{}'];
 
   // load all inputs
@@ -259,5 +259,5 @@ async function parseVariables(variables: string[]): Promise<{ [key: string]: any
     vars.push(JSON.parse(await load(v)));
   }
 
-  return rt.merge(...vars);
+  return rt.flattenAndMerge(separator, ...vars);
 }

--- a/tests/flattenAndMerge.test.ts
+++ b/tests/flattenAndMerge.test.ts
@@ -1,12 +1,12 @@
-import { merge } from '../src';
+import { flattenAndMerge } from '../src';
 
-describe('merge', () => {
+describe('flattenAndMerge', () => {
   it('single object', () => {
     // arrange
     const source = { string: 'hello' };
 
     // act
-    const result = merge(source);
+    const result = flattenAndMerge('.', source);
 
     // assert
     expect(result).not.toBe(source);
@@ -19,10 +19,10 @@ describe('merge', () => {
     const source2 = { msg: 'hello world!', count: 2 };
 
     // act
-    const result = merge(source1, source2);
+    const result = flattenAndMerge('.', source1, source2);
 
     // assert
-    expect(result).toEqual({ msg: 'hello world!', private: true, count: 2 });
+    expect(result).toEqual({ msg: 'hello world!', private: 'true', count: '2' });
   });
 
   it('objects with array', async () => {
@@ -31,10 +31,15 @@ describe('merge', () => {
     const source2 = { msgs: ['hello', 'world!'], count: 2 };
 
     // act
-    const result = merge(source1, source2);
+    const result = flattenAndMerge('.', source1, source2);
 
     // assert
-    expect(result).toEqual({ msgs: ['hello', 'world!'], private: true, count: 2 });
+    expect(result).toEqual({
+      'msgs.0': 'hello',
+      'msgs.1': 'world!',
+      private: 'true',
+      count: '2'
+    });
   });
 
   it('complex objects', async () => {
@@ -49,16 +54,30 @@ describe('merge', () => {
       obj: { scalar2: false, obj: { scalar: '1.3', array: ['hello world!'] } },
       count: 2
     };
+    const source3 = [
+      'a',
+      {
+        scalar: 2
+      }
+    ];
 
     // act
-    const result = merge(source1, source2);
+    const result = flattenAndMerge('.', source1, source2, source3);
 
     // assert
     expect(result).toEqual({
       scalar: 'string',
-      array: [{ scalar: 'hello' }],
-      obj: { scalar: true, scalar2: false, obj: { scalar: '1.3', array: ['hello world!'], scalar2: 'a' } },
-      count: 2
+      'array.0.scalar': 'hello',
+      'array.1.scalar': 'world!',
+      'obj.scalar': 'true',
+      'obj.scalar2': 'false',
+      'obj.obj.scalar': '1.3',
+      'obj.obj.array.0': 'hello world!',
+      'obj.obj.array.1.value': 'world!',
+      'obj.obj.scalar2': 'a',
+      count: '2',
+      '0': 'a',
+      '1.scalar': '2'
     });
   });
 });


### PR DESCRIPTION
Replace helper function `merge` with `flattenAndMerge` to support passing arrays as objects.