### PR TITLE
Add MissingVariables.Action.Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ replacetokens --sources
               [--help]
               [--include-dot-paths]
               [--log-level {debug, info, warn, error, off}]
-              [--missing-var-action {none, keep, replace}]
+              [--missing-var-action {none, keep, replace, error}]
               [--missing-var-default]
               [--missing-var-log {off, warn, error}]
               [--no-log-color]
@@ -114,6 +114,7 @@ Accepted values:
 - `none`: replace with empty string **and** log key not found
 - `keep`: leave token **and** log key not found
 - `replace`: replace with _missing-var-default_
+- `error`: throw error if key not found
 
 `--missing-var-default <string>`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export class MissingVariables {
     static readonly None: string = 'none';
     static readonly Keep: string = 'keep';
     static readonly Replace: string = 'replace';
+    static readonly Error: string = 'error';
   };
 }
 
@@ -578,6 +579,9 @@ function replaceTokensInString(
           ++counters.defaults;
           ++counters.replaced;
           break;
+
+        case MissingVariables.Action.Error:
+          throw new Error(`missing variable value for '${name}'`);
 
         default:
           logVariableNotFound();


### PR DESCRIPTION
Using this in a pipeline for CI/CD, I want to know when a variable was not properly provided by the pipeline and fail a deploy if a variable is missing. 